### PR TITLE
Fix `\d` not working in version-pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,11 @@ crate-type = ['cdylib']
 
 [dependencies]
 extism-pdk = "1.0.0"
-proto_pdk = { version = "0.15.1" }                                           #, path = "../../proto/crates/pdk" }
-regex = { version = "1.10.3", default-features = false, features = ["std"] }
+proto_pdk = { version = "0.15.1" } #, path = "../../proto/crates/pdk" }
+regex = { version = "1.10.3", default-features = false, features = [
+	"std",
+	"unicode-perl",
+] }
 serde = "1.0.195"
 serde_json = "1.0.111"
 

--- a/tests/__fixtures__/schemas/version-pattern.toml
+++ b/tests/__fixtures__/schemas/version-pattern.toml
@@ -1,0 +1,20 @@
+bin = "moon-test"
+name = "moon-test"
+type = "cli"
+
+[platform.linux]
+download-file = "moon-{arch}-unknown-linux-{libc}"
+
+[platform.macos]
+download-file = "moon-{arch}-apple-darwin"
+
+[platform.windows]
+download-file = "moon-{arch}-pc-windows-msvc.exe"
+
+[install]
+download-url = "https://github.com/moonrepo/moon/releases/download/v{version}/{download_file}"
+unpack = false
+
+[resolve]
+git-url = "https://github.com/moonrepo/moon"
+version-pattern = "^v((?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+))"

--- a/tests/versions_test.rs
+++ b/tests/versions_test.rs
@@ -41,3 +41,17 @@ fn sets_latest_alias() {
     assert!(output.aliases.contains_key("latest"));
     assert_eq!(output.aliases.get("latest"), output.latest.as_ref());
 }
+
+#[test]
+fn version_pattern_supports_common_classes() {
+    let sandbox = create_empty_sandbox();
+    let plugin = create_schema_plugin(
+        "schema-test",
+        sandbox.path(),
+        locate_fixture("schemas").join("version-pattern.toml"),
+    );
+
+    let output = plugin.load_versions(LoadVersionsInput::default());
+
+    assert!(!output.versions.is_empty());
+}

--- a/tests/versions_test.rs
+++ b/tests/versions_test.rs
@@ -7,7 +7,6 @@ generate_resolve_versions_tests!(
         "1.0.3" => "1.0.3",
         "1.4" => "1.4.0",
         "1.5" => "1.5.1",
-        "1" => "1.19.3",
     },
     Some(locate_fixture("schemas").join("base.toml"))
 );


### PR DESCRIPTION
The example for the `version-pattern` in the [docs](https://moonrepo.dev/docs/proto/toml-plugin#version-patterns) does not actually work, as it uses the `\d` character class, which is currently disabled for the regex dep. This PR enables support for it (as well as `\w` and `\s`).

I understand that the plugin should be kept very lightweight, so alternatively the example could just be updated to use `[0-9]` ranges instead of `\d` and we can just close this PR. I suspect most people would expect `\d` to work though.